### PR TITLE
fix setup.py to install properly with pip 18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from setuptools import find_packages, setup
 
-from pip.req import parse_requirements
-
+try:
+    from pip._internal.req import parse_requirements
+except ImportError:
+    from pip.req import parse_requirements
 
 def get_requirements(filename):
     try:
-        from pip.download import PipSession
-
+        from pip._internal.download import PipSession
         session = PipSession()
+
     except ImportError:
         session = None
 
     reqs = parse_requirements(filename, session=session)
 
     return [str(r.req) for r in reqs]
-
 
 setup_args = dict(
     name='flask-letsencrypt',


### PR DESCRIPTION
Easy enough to fix! Thanks for the pointer to that commit, it helped a lot.

I ran this with `pip 18.0` and it installs fine. 
Also ran the tests just to be sure -- those pass as well (as expected).